### PR TITLE
feat: `Bouncer` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ As a counterpart, you can use the `Cannot` component to render the button only i
 </template>
 ```
 
-The `Bouncer` component offers a more flexible and centralized way to handle both can and cannot scenarios within a single component. Instead of using separate Can and Cannot components, you can leverage the Bouncer component and its [named slots](https://vuejs.org/guide/components/slots.html#named-slots) to handle both states in a unified block.
+The `Bouncer` component offers a more flexible and centralized way to handle both can and cannot scenarios within a single component. Instead of using separate `Can` and `Cannot` components, you can leverage the Bouncer component and its [named slots](https://vuejs.org/guide/components/slots.html#named-slots) to handle both states in a unified block.
 
 ```vue
 <Bouncer

--- a/README.md
+++ b/README.md
@@ -239,12 +239,12 @@ The `Bouncer` component offers a more flexible and centralized way to handle bot
   :bouncer-ability="editPost"
   :args="[post]" // Optional if the ability does not take any arguments
 >
-  <template v-slot:can> 
-    <button>Edit</button> 
+  <template #can>
+    <button>Edit</button>
   </template>
-  
-  <template v-slot:cannot> 
-    <p>You're not allowed to edit the post.</p> 
+
+  <template #cannot>
+    <p>You're not allowed to edit the post.</p>
   </template>
 </Bouncer>
 ```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,23 @@ As a counterpart, you can use the `Cannot` component to render the button only i
 </template>
 ```
 
+The `Bouncer` component offers a more flexible and centralized way to handle both can and cannot scenarios within a single component. Instead of using separate Can and Cannot components, you can leverage the Bouncer component and its [named slots](https://vuejs.org/guide/components/slots.html#named-slots) to handle both states in a unified block.
+
+```vue
+<Bouncer
+  :bouncer-ability="editPost"
+  :args="[post]" // Optional if the ability does not take any arguments
+>
+  <template v-slot:can> 
+    <button>Edit</button> 
+  </template>
+  
+  <template v-slot:cannot> 
+    <p>You're not allowed to edit the post.</p> 
+  </template>
+</Bouncer>
+```
+
 ## Contribution
 
 <details>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,6 +17,6 @@ export default createConfigForNuxt({
 }).overrideRules({
   '@typescript-eslint/no-explicit-any': 'off',
   'vue/multi-word-component-names': ['error', {
-    ignores: ['Can', 'Cannot'],
+    ignores: ['Can', 'Cannot', 'Bouncer'],
   }],
 })

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -29,5 +29,22 @@ const product: Product = {
         I cannot edit a product.
       </p>
     </Cannot>
+
+    <Bouncer
+      :bouncer-ability="deleteProduct"
+      :args="[product]"
+    >
+      <template #can>
+        <p>
+          I can delete a product.
+        </p>
+      </template>
+
+      <template #cannot>
+        <p>
+          I cannot delete a product.
+        </p>
+      </template>
+    </Bouncer>
   </div>
 </template>

--- a/playground/utils/abilities.ts
+++ b/playground/utils/abilities.ts
@@ -9,3 +9,7 @@ export const editProduct = defineAbility((user: User, product: Product) => {
   console.log('user', user, product)
   return user.id === product.ownerId
 })
+
+export const deleteProduct = defineAbility((user: User, product: Product) => {
+  return user.id === product.ownerId
+})

--- a/src/runtime/components/Bouncer.vue
+++ b/src/runtime/components/Bouncer.vue
@@ -1,0 +1,22 @@
+<script lang="ts" setup generic="Ability extends BouncerAbility<any>">
+import type { AuthorizerResponse, BouncerAbility } from '../../utils'
+import { allows } from '#imports'
+
+type PropsArgs = Ability extends { original: (user: any, ...args: infer Args) => AuthorizerResponse } ? Args : never
+
+const props = defineProps<{
+  bouncerAbility: Ability
+  args?: PropsArgs
+}>()
+
+const can = await allows(props.bouncerAbility, ...(props.args ?? [] as unknown as PropsArgs))
+</script>
+
+<template>
+  <template v-if="can">
+    <slot name="can" />
+  </template>
+  <template v-else>
+    <slot name="cannot" />
+  </template>
+</template>

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -10,14 +10,17 @@ describe('Components', async () => {
   it('should render correctly', async () => {
     const page = await createPage('/')
 
-    expect(await page.getByTestId('view-can').isVisible()).toBeTruthy()
-    expect(await page.getByTestId('view-not-can').isVisible()).toBeFalsy()
-    expect(await page.getByTestId('view-cannot').isVisible()).toBeFalsy()
-    expect(await page.getByTestId('view-not-cannot').isVisible()).toBeTruthy()
-    expect(await page.getByTestId('view-bouncer-can').isVisible()).toBeTruthy()
-    expect(await page.getByTestId('view-bouncer-cannot').isVisible()).toBeTruthy()
-    expect(await page.getByTestId('view-not-bouncer-cannot').isVisible()).toBeFalsy()
-    expect(await page.getByTestId('view-not-bouncer-can').isVisible()).toBeFalsy()
+    expect(await page.getByTestId('can-visible').isVisible()).toBeTruthy()
+    expect(await page.getByTestId('can-invisible').isVisible()).toBeFalsy()
+
+    expect(await page.getByTestId('cannot-invisible').isVisible()).toBeFalsy()
+    expect(await page.getByTestId('cannot-visible').isVisible()).toBeTruthy()
+
+    expect(await page.getByTestId('bouncer-can-visible').isVisible()).toBeTruthy()
+    expect(await page.getByTestId('bouncer-cannot-invisible').isVisible()).toBeFalsy()
+
+    expect(await page.getByTestId('bouncer-can-invisible').isVisible()).toBeFalsy()
+    expect(await page.getByTestId('bouncer-cannot-visible').isVisible()).toBeTruthy()
 
     await page.close()
   })

--- a/test/component.spec.ts
+++ b/test/component.spec.ts
@@ -14,6 +14,10 @@ describe('Components', async () => {
     expect(await page.getByTestId('view-not-can').isVisible()).toBeFalsy()
     expect(await page.getByTestId('view-cannot').isVisible()).toBeFalsy()
     expect(await page.getByTestId('view-not-cannot').isVisible()).toBeTruthy()
+    expect(await page.getByTestId('view-bouncer-can').isVisible()).toBeTruthy()
+    expect(await page.getByTestId('view-bouncer-cannot').isVisible()).toBeTruthy()
+    expect(await page.getByTestId('view-not-bouncer-cannot').isVisible()).toBeFalsy()
+    expect(await page.getByTestId('view-not-bouncer-can').isVisible()).toBeFalsy()
 
     await page.close()
   })

--- a/test/fixtures/components/app/app.vue
+++ b/test/fixtures/components/app/app.vue
@@ -15,32 +15,32 @@ const cannot = defineAbility(() => {
     <Can
       :bouncer-ability="can"
     >
-      <div data-testid="view-can">
-        Can
+      <div data-testid="can-visible">
+        Can Visible
       </div>
     </Can>
 
     <Can
       :bouncer-ability="cannot"
     >
-      <div data-testid="view-not-can">
-        Cannot
+      <div data-testid="can-invisible">
+        Can Invisible
       </div>
     </Can>
 
     <Cannot
       :bouncer-ability="can"
     >
-      <div data-testid="view-cannot">
-        Cannot
+      <div data-testid="cannot-invisible">
+        Cannot Invisible
       </div>
     </Cannot>
 
     <Cannot
       :bouncer-ability="cannot"
     >
-      <div data-testid="view-not-cannot">
-        Can
+      <div data-testid="cannot-visible">
+        Cannot Visible
       </div>
     </Cannot>
 
@@ -48,14 +48,14 @@ const cannot = defineAbility(() => {
       :bouncer-ability="can"
     >
       <template #can>
-        <div data-testid="view-bouncer-can">
-          Can
+        <div data-testid="bouncer-can-visible">
+          Bouncer Can Visible
         </div>
       </template>
 
       <template #cannot>
-        <div data-testid="view-not-bouncer-cannot">
-          Cannot
+        <div data-testid="bouncer-cannot-invisible">
+          Bouncer Cannot Invisible
         </div>
       </template>
     </Bouncer>
@@ -64,14 +64,14 @@ const cannot = defineAbility(() => {
       :bouncer-ability="cannot"
     >
       <template #can>
-        <div data-testid="view-not-bouncer-can">
-          Cannot
+        <div data-testid="bouncer-can-invisible">
+          Bouncer Can Invisible
         </div>
       </template>
 
       <template #cannot>
-        <div data-testid="view-bouncer-cannot">
-          Can
+        <div data-testid="bouncer-cannot-visible">
+          Bouncer Cannot Visible
         </div>
       </template>
     </Bouncer>

--- a/test/fixtures/components/app/app.vue
+++ b/test/fixtures/components/app/app.vue
@@ -43,5 +43,37 @@ const cannot = defineAbility(() => {
         Can
       </div>
     </Cannot>
+
+    <Bouncer
+      :bouncer-ability="can"
+    >
+      <template v-slot:can> 
+        <div data-testid="view-bouncer-can">
+          Can
+        </div>
+      </template>
+  
+      <template v-slot:cannot> 
+        <div data-testid="view-not-bouncer-cannot">
+          Cannot
+        </div>
+      </template>
+    </Bouncer>
+
+    <Bouncer
+      :bouncer-ability="cannot"
+    >
+      <template v-slot:can> 
+        <div data-testid="view-not-bouncer-can">
+          Cannot
+        </div>
+      </template>
+  
+      <template v-slot:cannot> 
+        <div data-testid="view-bouncer-cannot">
+          Can
+        </div>
+      </template>
+    </Bouncer>
   </div>
 </template>

--- a/test/fixtures/components/app/app.vue
+++ b/test/fixtures/components/app/app.vue
@@ -47,13 +47,13 @@ const cannot = defineAbility(() => {
     <Bouncer
       :bouncer-ability="can"
     >
-      <template v-slot:can> 
+      <template #can>
         <div data-testid="view-bouncer-can">
           Can
         </div>
       </template>
-  
-      <template v-slot:cannot> 
+
+      <template #cannot>
         <div data-testid="view-not-bouncer-cannot">
           Cannot
         </div>
@@ -63,13 +63,13 @@ const cannot = defineAbility(() => {
     <Bouncer
       :bouncer-ability="cannot"
     >
-      <template v-slot:can> 
+      <template #can>
         <div data-testid="view-not-bouncer-can">
           Cannot
         </div>
       </template>
-  
-      <template v-slot:cannot> 
+
+      <template #cannot>
         <div data-testid="view-bouncer-cannot">
           Can
         </div>


### PR DESCRIPTION
From the README:

> The `Bouncer` component offers a more flexible and centralized way to handle both can and cannot scenarios within a single component. Instead of using separate Can and Cannot components, you can leverage the Bouncer component and its [named slots](https://vuejs.org/guide/components/slots.html#named-slots) to handle both states in a unified block.