### PR TITLE
Add Nuxt 4 compatibility

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'authorization',
     version,
     compatibility: {
-      nuxt: '>=3.0.0',
+      nuxt: '>=3.0.0 || ^4.0.0',
     },
   },
   // Default configuration options of the Nuxt module

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'authorization',
     version,
     compatibility: {
-      nuxt: '>=3.0.0 || ^4.0.0',
+      nuxt: '^3.0.0 || ^4.0.0',
     },
   },
   // Default configuration options of the Nuxt module


### PR DESCRIPTION
Closes #63 by adding `^4.0.0` to the compatibility range for Nuxt. 

I have not yet tested this, although I have been using this module with `compatibilityVersion: 4` for some time without issue.